### PR TITLE
fix if entry file is nested from root folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const chokidar = require('chokidar');
 const isDev = require('electron-is-dev');
 const dateTime = require('date-time');
 const chalk = require('chalk');
+const findUp = require('find-up');
 
 function getMainProcessPaths(topModuleObject) {
 	const cwd = path.dirname(topModuleObject.filename);
@@ -27,7 +28,7 @@ function getMainProcessPaths(topModuleObject) {
 	return paths;
 }
 
-module.exports = (moduleObj, options) => {
+module.exports = async (moduleObj, options) => {
 	// This module should be a dev dependency, but guard
 	// this in case the user included it as a dependency
 	if (!isDev) {
@@ -43,7 +44,7 @@ module.exports = (moduleObj, options) => {
 		...options
 	};
 
-	const cwd = path.dirname(moduleObj.filename);
+	const cwd = path.dirname(await findUp('package.json'));
 	const mainProcessPaths = getMainProcessPaths(moduleObj);
 	const watchPaths = options.watchRenderer ? cwd : [...mainProcessPaths];
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"chalk": "^2.4.2",
 		"chokidar": "^3.0.0",
 		"date-time": "^3.1.0",
-		"electron-is-dev": "^1.1.0"
+		"electron-is-dev": "^1.1.0",
+		"find-up": "^4.1.0"
 	},
 	"devDependencies": {
 		"electron": "^5.0.1",


### PR DESCRIPTION
This will fix #7.

As mentioned in here #7 (comment) using find-up package searching for nearest package.json file and use it as a root path to look for changes.

Not sure, how to do write tests for this. Manually tested by nesting the main entry file inside the root folder.

## How is this tested?

To test this, I wrote following code inside `test/main/main.js`

```
require('../../')(module, {
	debug: true
});
```

and import it in `test/index.js`
```
require('./main/main.js')
```

and add `package.json` file inside test folder with basic options

```

  "scripts": {
    "start": "electron ."
  },
  "devDependencies": {
    "electron": "^5.0.1"
  }
}
```

now run `npm run test`. Now if you change `index.html` app will reload.