### PR TITLE
Ensure relaunch is only called once

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = (moduleObject, options) => {
 	const cwd = packageDirectory ? path.dirname(packageDirectory) : mainProcessDirectory;
 	const mainProcessPaths = getMainProcessPaths(moduleObject, cwd);
 	const watchPaths = options.watchRenderer ? cwd : [...mainProcessPaths];
-	let isReloading = false;
+	let isRelaunching = false;
 
 	const watcher = chokidar.watch(watchPaths, {
 		cwd,
@@ -72,12 +72,14 @@ module.exports = (moduleObject, options) => {
 		}
 
 		if (mainProcessPaths.has(path.join(cwd, filePath))) {
-			if (!isReloading) {
+			// Prevent multiple instances of Electron from being started due to change
+			// handler being called multiple times before original instance exits
+			if (!isRelaunching) {
 				electron.app.relaunch();
 				electron.app.exit(0);
 			}
 
-			isReloading = true;
+			isRelaunching = true;
 		} else {
 			for (const window_ of electron.BrowserWindow.getAllWindows()) {
 				window_.webContents.reloadIgnoringCache();

--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ module.exports = (moduleObject, options) => {
 		}
 
 		if (mainProcessPaths.has(path.join(cwd, filePath))) {
-			// Prevent multiple instances of Electron from being started due to change
-			// handler being called multiple times before original instance exits
+			// Prevent multiple instances of Electron from being started due to the change
+			// handler being called multiple times before the original instance exits.
 			if (!isRelaunching) {
 				electron.app.relaunch();
 				electron.app.exit(0);

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = (moduleObject, options) => {
 	const cwd = packageDirectory ? path.dirname(packageDirectory) : mainProcessDirectory;
 	const mainProcessPaths = getMainProcessPaths(moduleObject, cwd);
 	const watchPaths = options.watchRenderer ? cwd : [...mainProcessPaths];
+	let isReloading = false;
 
 	const watcher = chokidar.watch(watchPaths, {
 		cwd,
@@ -71,8 +72,12 @@ module.exports = (moduleObject, options) => {
 		}
 
 		if (mainProcessPaths.has(path.join(cwd, filePath))) {
-			electron.app.relaunch();
-			electron.app.exit(0);
+			if (!isReloading) {
+				electron.app.relaunch();
+				electron.app.exit(0);
+			}
+
+			isReloading = true;
 		} else {
 			for (const window_ of electron.BrowserWindow.getAllWindows()) {
 				window_.webContents.reloadIgnoringCache();


### PR DESCRIPTION
According to Electron's documentation, calling app.relaunch multiple times will trigger multiple new instances. This situation can happen when a user saves a file, and then a formatter like Prettier formats and saves before electron has exited, triggering multiple "change" events (and therefore multiple relaunches).

Fixes #3
Closes #6