### PR TITLE
Fix crash reporter on macOS because chokidar were not quitting properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ module.exports = (moduleObject, options) => {
 		].concat(options.ignore)
 	});
 
+	electron.app.on('quit', () => {
+		watcher.close();
+	});
+
 	if (options.debug) {
 		watcher.on('ready', () => {
 			console.log('Watched paths:', inspect(watcher.getWatched(), {compact: false, colors: true}));


### PR DESCRIPTION
Hi, and first, thanks for your amazing work.

As as fix to my (now closed) issue #20, I dig into the problem and found the cause. It is not caused by electron at all, but by chokidar. When the application quit and restart, chokidar receives a SIGABORT, which cause the system crash reporter of macOS trigger because `Oh no! A software didn't quit properly!`. When properly quitting chokidar, the error vanishes.

The solution is to subscribe to the `quit` event of electron and closing chokidar at this moment, which ensures chokidar is correctly quitted whether the user quit (`Cmd + Q` for instance) or because the application relaunch on save.