### PR TITLE
Fix Readme: Add options object to require statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ The following must be included in the app entry file, usually named `index.js`:
 
 ```js
 try {
-	require('electron-reloader')(module);
+	require('electron-reloader')(module, {});
 } catch {}
 ```
 


### PR DESCRIPTION
The hot reloader doesn't work when you use the require snippet from the readme: 
```js
try {
	require('electron-reloader')(module);
} catch {}
```

If print the error log, It throws the following error:
```
TypeError: Cannot read properties of undefined (reading 'ignored')
    at module.exports (/media/jafb-disk/personal-projects/filelify/node_modules/electron-reloader/index.js:45:14)
    at Object.<anonymous> (/media/jafb-disk/personal-projects/filelify/main.js:23:33)
    at Module._compile (node:internal/modules/cjs/loader:1116:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1169:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:829:12)
    at Function.c._load (node:electron/js2c/asar_bundle:5:13331)
    at loadApplicationPackage (/media/jafb-disk/personal-projects/filelify/node_modules/electron/dist/resources/default_app.asar/main.js:110:16)
    at Object.<anonymous> (/media/jafb-disk/personal-projects/filelify/node_modules/electron/dist/resources/default_app.asar/main.js:222:9)
    at Module._compile (node:internal/modules/cjs/loader:1116:14)
```

But if you pass the 2nd parameter (options param) as a empty object, there is no problem 👍🏻:
 ```js
try {
	require('electron-reloader')(module, {});
} catch {}
```

This look like a simple problem which will be solved, but this _documentation fix_  should help temporarily 😄 

PD: 
The real problem seems to be here, but I don't wanted to change the code, I decided to let the dev do his job 😸  
![image](https://user-images.githubusercontent.com/50496660/155042677-f4e7928b-8179-437b-8415-0163c2c3a837.png)
